### PR TITLE
fix: refactor gc collection aggregation into domain metrics

### DIFF
--- a/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/GCReportService.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/GCReportService.kt
@@ -6,6 +6,7 @@ import io.github.cdsap.gcreport.plugin.extensions.getFileName
 import io.github.cdsap.gcreport.plugin.extensions.getFileNameCsvLog
 import io.github.cdsap.gcreport.plugin.histogram.Histogram
 import io.github.cdsap.gcreport.plugin.model.Bucket
+import io.github.cdsap.gcreport.plugin.model.GCCollectionMetrics
 import io.github.cdsap.gcreport.plugin.parser.GCLogReader
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
@@ -39,6 +40,7 @@ abstract class GCReportService : BuildService<GCReportService.Params>, AutoClose
 
                 val headers = "Collection type,Occurrences\n"
                 var content = ""
+                val collectionMetrics = GCCollectionMetrics(gcEntries)
 
                 println(
                     table {
@@ -54,11 +56,11 @@ abstract class GCReportService : BuildService<GCReportService.Params>, AutoClose
                             }
                         }
                         row("Collection type", "Occurrences")
-                        gcEntries.groupBy { it.description }.forEach { (t, u) ->
-                            content += "$t,${u.size}\n"
+                        collectionMetrics.countsByDescription().forEach { (description, count) ->
+                            content += "$description,$count\n"
                             row {
-                                cell(t)
-                                cell(u.size) {
+                                cell(description)
+                                cell(count) {
                                     alignment = TextAlignment.MiddleRight
                                 }
                             }
@@ -93,8 +95,7 @@ abstract class GCReportService : BuildService<GCReportService.Params>, AutoClose
                             }
                             row("Bucket", "Occurrences")
                             val histogram = Histogram(parameters.histogramBucket.get())
-                            val entries =
-                                histogram.getHistogram(gcEntries.filter { it.description != "Concurrent Mark Cycle" })
+                            val entries = histogram.getHistogram(collectionMetrics.entriesForHistogram())
                             entries.forEach {
                                 contentHistogram += "${it.first},${it.second}\n"
                                 row {

--- a/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/model/GCCollectionMetrics.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/model/GCCollectionMetrics.kt
@@ -1,0 +1,16 @@
+package io.github.cdsap.gcreport.plugin.model
+
+class GCCollectionMetrics(
+    private val entries: List<GCEntry>,
+) {
+    fun countsByDescription(): Map<String, Int> =
+        entries.groupBy { it.description }.mapValues { (_, groupedEntries) -> groupedEntries.size }
+
+    fun entriesForHistogram(): List<GCEntry> = entries.filter { it.description != CONCURRENT_MARK_CYCLE }
+
+    fun totalCollections(): Int = entriesForHistogram().size
+
+    companion object {
+        const val CONCURRENT_MARK_CYCLE = "Concurrent Mark Cycle"
+    }
+}

--- a/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/output/DevelocityValues.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/output/DevelocityValues.kt
@@ -4,6 +4,7 @@ import com.gradle.develocity.agent.gradle.DevelocityConfiguration
 import io.github.cdsap.gcreport.plugin.GCReportExtension
 import io.github.cdsap.gcreport.plugin.extensions.getFileName
 import io.github.cdsap.gcreport.plugin.histogram.Histogram
+import io.github.cdsap.gcreport.plugin.model.GCCollectionMetrics
 import io.github.cdsap.gcreport.plugin.model.GCEntry
 
 class DevelocityValues(
@@ -13,18 +14,19 @@ class DevelocityValues(
     private val extension: GCReportExtension,
 ) {
     fun report() {
+        val collectionMetrics = GCCollectionMetrics(gcEntries)
         develocityConfiguration.buildScan {
-            gcEntries.groupBy { it.description }.forEach { t, u ->
-                value("gc-${log.getFileName()}-$t", "${u.size}")
+            collectionMetrics.countsByDescription().forEach { (description, count) ->
+                value("gc-${log.getFileName()}-$description", "$count")
             }
-            val counter = gcEntries.filter { it.description != "Concurrent Mark Cycle" }.count()
+            val counter = collectionMetrics.totalCollections()
             if (counter != 0) {
                 value("gc-${log.getFileName()}-total-collections", "$counter")
             }
             if (extension.histogramEnabled.get()) {
                 val histogram =
                     Histogram(extension.histogramBucket.get()).getHistogram(
-                        gcEntries.filter { it.description != "Concurrent Mark Cycle" },
+                        collectionMetrics.entriesForHistogram(),
                     )
                 var histogramText = "["
                 histogram.forEach {

--- a/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/model/GCCollectionMetricsTest.kt
+++ b/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/model/GCCollectionMetricsTest.kt
@@ -1,0 +1,61 @@
+package io.github.cdsap.gcreport.plugin.model
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class GCCollectionMetricsTest {
+    @Test
+    fun `countsByDescription groups all entries including Concurrent Mark Cycle`() {
+        val entries =
+            listOf(
+                gcEntry(description = "Pause Young (Normal)"),
+                gcEntry(description = "Pause Young (Normal)"),
+                gcEntry(description = GCCollectionMetrics.CONCURRENT_MARK_CYCLE),
+                gcEntry(description = "Pause Full (System.gc())"),
+            )
+        val metrics = GCCollectionMetrics(entries)
+
+        assertEquals(
+            mapOf(
+                "Pause Young (Normal)" to 2,
+                GCCollectionMetrics.CONCURRENT_MARK_CYCLE to 1,
+                "Pause Full (System.gc())" to 1,
+            ),
+            metrics.countsByDescription(),
+        )
+    }
+
+    @Test
+    fun `entriesForHistogram excludes Concurrent Mark Cycle`() {
+        val concurrentMarkCycle = gcEntry(description = GCCollectionMetrics.CONCURRENT_MARK_CYCLE)
+        val youngPause = gcEntry(description = "Pause Young (Normal)")
+        val entries = listOf(youngPause, concurrentMarkCycle, youngPause)
+        val metrics = GCCollectionMetrics(entries)
+
+        assertEquals(listOf(youngPause, youngPause), metrics.entriesForHistogram())
+    }
+
+    @Test
+    fun `totalCollections counts entries excluding Concurrent Mark Cycle`() {
+        val entries =
+            listOf(
+                gcEntry(description = "Pause Young (Normal)"),
+                gcEntry(description = GCCollectionMetrics.CONCURRENT_MARK_CYCLE),
+                gcEntry(description = "Pause Young (Normal)"),
+                gcEntry(description = GCCollectionMetrics.CONCURRENT_MARK_CYCLE),
+            )
+        val metrics = GCCollectionMetrics(entries)
+
+        assertEquals(2, metrics.totalCollections())
+    }
+
+    private fun gcEntry(description: String): GCEntry =
+        GCEntry(
+            timeStamp = "1.00",
+            timeStampUnit = "s",
+            id = "1",
+            description = description,
+            duration = "10",
+            durationUnit = "ms",
+        )
+}


### PR DESCRIPTION
## Summary

### Problem

Domain rules for summarizing parsed GC logs are duplicated and embedded in infrastructure code. `GCReportService.kt` groups `GCEntry` by `description` and separately filters `"Concurrent Mark Cycle"` for histogram output; `DevelocityValues.kt` repeats the same `groupBy` and `"Concurrent Mark Cycle"` filter for total-count and histogram values. The event name is a magic string in multiple Gradle-facing classes instead of living with the `model` types.

### Why this matters

When collection-summary rules change (for example, excluding another multi-phase GC event from histograms), maintainers must update multiple output paths and risk inconsistent console, CSV, and Develocity metrics. The duplication also makes the core reporting behavior harder to unit test without Gradle services or Develocity APIs.

### Proposed change

Add a small domain type in the `model` package, e.g. `GCCollectionMetrics` (or `List<GCEntry>` extension functions), that centralizes: (1) `countsByDescription()` for the occurrence table, (2) `entriesForHistogram()` excluding `"Concurrent Mark Cycle"`, and (3) `totalCollections()` based on that filtered set. Replace the inline `groupBy` / `filter` logic in `GCReportService.kt` and `DevelocityValues.kt` with calls to this type. Add a focused unit test for the metrics behavior using existing `GCEntry` fixtures.

### Notes

This follows a thin domain-service boundary: `GCEntry` parsing stays infrastructure, while collection summarization becomes an application/domain concern reusable by console, CSV, and Develocity adapters. It is intentionally small—one new type and two call-site updates—without introducing a framework or restructuring the plugin lifecycle.

Fixes #7

## Changes

- `gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/GCReportService.kt`
- `gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/model/GCCollectionMetrics.kt`
- `gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/output/DevelocityValues.kt`
- `gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/model/GCCollectionMetricsTest.kt`

## Verification

- `./gradlew ktlintCheck`
- `./gradlew test`
