### PR TITLE
fix: gradle 9 blocker: declare junit-platform-launcher on the test runti

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     testImplementation(libs.ktor.client.cio)
     testImplementation(libs.gson)
     testImplementation(libs.junit.jupiter)
+    testRuntimeOnly(libs.junit.platform.launcher)
 }
 
 tasks.test {

--- a/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GradlePluginBuildConfigTest.kt
+++ b/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GradlePluginBuildConfigTest.kt
@@ -1,0 +1,29 @@
+package io.github.cdsap.gcreport.plugin
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class GradlePluginBuildConfigTest {
+    @Test
+    fun `gradle plugin build declares junit platform launcher on test runtime classpath`() {
+        val buildGradle = File("build.gradle.kts").canonicalFile
+        val buildGradleContents = buildGradle.readText()
+
+        assertTrue(
+            buildGradleContents.contains("testRuntimeOnly(libs.junit.platform.launcher)"),
+            "build.gradle.kts must declare junit-platform-launcher on the test runtime classpath",
+        )
+    }
+
+    @Test
+    fun `version catalog declares junit platform launcher`() {
+        val versionCatalog = File("../gradle/libs.versions.toml").canonicalFile
+        val versionCatalogContents = versionCatalog.readText()
+
+        assertTrue(
+            versionCatalogContents.contains("junit-platform-launcher"),
+            "gradle/libs.versions.toml must declare junit-platform-launcher",
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ picnic = { group = "com.jakewharton.picnic", name = "picnic", version.ref = "pic
 ktor-client-cio = { group = "io.ktor", name = "ktor-client-cio", version.ref = "ktor-client-cio" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter" }
+junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary

### Problem

`./gradlew build --warning-mode all` emits a deprecation that is scheduled for removal in Gradle 9:

```
> Task :gradle-plugin:test
The automatic loading of test framework implementation dependencies has been deprecated.
This is scheduled to be removed in Gradle 9.0. Declare the desired test framework directly
on the test suite or explicitly declare the test framework implementation dependencies on
the test's runtime classpath.
```

`gradle-plugin/build.gradle.kts` declares `testImplementation(libs.junit.jupiter)` but nothing puts `junit-platform-launcher` on the **test runtime** classpath, so Gradle is injecting it automatically.

Fixes #18

## Changes

- `gradle-plugin/build.gradle.kts`
- `gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GradlePluginBuildConfigTest.kt`
- `gradle/libs.versions.toml`

## Verification

- `./gradlew ktlintCheck`
- `./gradlew test`
