### PR TITLE
fix: refactor service registration to centralize gradle infrastructure w

### DIFF
--- a/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/GCReportPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/GCReportPlugin.kt
@@ -4,10 +4,6 @@ import com.gradle.develocity.agent.gradle.DevelocityConfiguration
 import io.github.cdsap.gcreport.plugin.report.DevelocityReport
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
-import org.gradle.build.event.BuildEventsListenerRegistry
-import org.gradle.internal.extensions.core.serviceOf
 import org.gradle.kotlin.dsl.create
 
 class GCReportPlugin : Plugin<Project> {
@@ -18,31 +14,11 @@ class GCReportPlugin : Plugin<Project> {
         target.gradle.rootProject {
             val extension = target.extensions.getByName("gcReport") as GCReportExtension
             if (develocityConfiguration != null) {
-                createService(target, extension, extension.enableConsoleLog)
+                ServiceHandler(target, extension, extension.enableConsoleLog).createService()
                 DevelocityReport(develocityConfiguration, extension).report()
             } else {
-                createService(target, extension)
+                ServiceHandler(target, extension).createService()
             }
         }
-    }
-
-    private fun createService(
-        project: Project,
-        extension: GCReportExtension,
-        enableLog: Property<Boolean>? = null,
-    ) {
-        val service: Provider<GCReportService> =
-            project.gradle.sharedServices.registerIfAbsent(
-                "gcReportService",
-                GCReportService::class.java,
-            ) {
-                val buildOutput = project.layout.buildDirectory.dir("reports/gcreport")
-                parameters.logs = extension.logs
-                parameters.histogramEnabled = extension.histogramEnabled
-                parameters.histogramBucket = extension.histogramBucket
-                parameters.buildOutput = buildOutput
-                parameters.enabledReport = if (enableLog == null) project.provider { true } else enableLog
-            }
-        project.serviceOf<BuildEventsListenerRegistry>().onTaskCompletion(service)
     }
 }

--- a/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/ServiceHandler.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/ServiceHandler.kt
@@ -1,0 +1,29 @@
+package io.github.cdsap.gcreport.plugin
+
+import org.gradle.api.Project
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.build.event.BuildEventsListenerRegistry
+import org.gradle.internal.extensions.core.serviceOf
+
+class ServiceHandler(
+    private val project: Project,
+    private val extension: GCReportExtension,
+    private val enableLog: Property<Boolean>? = null,
+) {
+    fun createService() {
+        val service: Provider<GCReportService> =
+            project.gradle.sharedServices.registerIfAbsent(
+                "gcReportService",
+                GCReportService::class.java,
+            ) {
+                val buildOutput = project.layout.buildDirectory.dir("reports/gcreport")
+                parameters.logs = extension.logs
+                parameters.histogramEnabled = extension.histogramEnabled
+                parameters.histogramBucket = extension.histogramBucket
+                parameters.buildOutput = buildOutput
+                parameters.enabledReport = if (enableLog == null) project.provider { true } else enableLog
+            }
+        project.serviceOf<BuildEventsListenerRegistry>().onTaskCompletion(service)
+    }
+}

--- a/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportServiceRegistrationTest.kt
+++ b/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportServiceRegistrationTest.kt
@@ -2,6 +2,7 @@ package io.github.cdsap.gcreport.plugin
 
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -12,14 +13,14 @@ class GCReportServiceRegistrationTest {
     lateinit var testProjectDir: File
 
     @Test
-    fun `GCReportService has a single registration path that configures enabledReport`() {
+    fun `GCReportService has a single registration path delegated to ServiceHandler`() {
         val mainKotlin = File("src/main/kotlin")
         require(mainKotlin.isDirectory) { "Expected Kotlin sources at ${mainKotlin.absolutePath}" }
 
         val kotlinSources =
             mainKotlin.walkTopDown().filter { it.isFile && it.extension == "kt" }.toList()
 
-        assertTrue(kotlinSources.none { it.name == "ServiceHandler.kt" })
+        assertTrue(kotlinSources.any { it.name == "ServiceHandler.kt" })
         assertTrue(kotlinSources.none { it.name == "ConsoleReport.kt" })
 
         val registrationSites =
@@ -29,8 +30,19 @@ class GCReportServiceRegistrationTest {
             }
 
         assertEquals(1, registrationSites.size, "expected exactly one GCReportService registration path")
-        assertEquals("GCReportPlugin.kt", registrationSites.single().name)
-        assertTrue(registrationSites.single().readText().contains("enabledReport"))
+        assertEquals("ServiceHandler.kt", registrationSites.single().name)
+
+        val serviceHandler = registrationSites.single().readText()
+        assertTrue(serviceHandler.contains("enabledReport"))
+        assertTrue(serviceHandler.contains("histogramEnabled"))
+        assertTrue(serviceHandler.contains("histogramBucket"))
+        assertTrue(serviceHandler.contains("buildOutput"))
+        assertTrue(serviceHandler.contains("parameters.logs"))
+
+        val plugin = kotlinSources.single { it.name == "GCReportPlugin.kt" }.readText()
+        assertTrue(plugin.contains("ServiceHandler"))
+        assertFalse(plugin.contains("registerIfAbsent"))
+        assertFalse(plugin.contains("\"gcReportService\""))
     }
 
     @Test
@@ -68,5 +80,56 @@ class GCReportServiceRegistrationTest {
         assertTrue(result.output.contains("GC Log: gc.log"))
         assertTrue(result.output.contains("Collection type"))
         assertTrue(testProjectDir.resolve("build/reports/gcreport/gc.csv").exists())
+    }
+
+    @Test
+    fun `with Develocity enableConsoleLog false disables console report output`() {
+        val gradleProperties = File(testProjectDir, "gradle.properties")
+        val gcLog = "${testProjectDir.absolutePath}/gc.log"
+        gradleProperties.writeText(
+            """
+            org.gradle.jvmargs=-Xlog:gc*:file=$gcLog
+            """.trimIndent(),
+        )
+
+        val settingsGradle = File(testProjectDir, "settings.gradle.kts")
+        settingsGradle.writeText(
+            """
+            plugins {
+                id("com.gradle.develocity") version "3.19"
+            }
+            develocity {
+                buildScan {
+                    publishing.onlyIf { false }
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val buildFile = File(testProjectDir, "build.gradle.kts")
+        buildFile.writeText(
+            """
+            plugins {
+                id("io.github.cdsap.gcreport")
+                java
+            }
+
+            gcReport {
+                logs.set(listOf("$gcLog"))
+                enableConsoleLog.set(false)
+            }
+            """,
+        )
+
+        val result =
+            GradleRunner.create()
+                .withProjectDir(testProjectDir)
+                .withArguments("tasks")
+                .withPluginClasspath()
+                .build()
+
+        assertFalse(result.output.contains("GC Log: gc.log"))
+        assertFalse(result.output.contains("Collection type"))
+        assertFalse(testProjectDir.resolve("build/reports/gcreport/gc.csv").exists())
     }
 }


### PR DESCRIPTION
## Summary

### Problem

GCReportPlugin.kt duplicates the shared-service registration implemented by ServiceHandler.kt, while ConsoleReport.kt only wraps the unused ServiceHandler path. The duplicated paths can diverge, especially around enabledReport configuration.

### Why this matters

Gradle lifecycle and shared-service wiring are infrastructure concerns. Keeping two registration implementations increases maintenance risk and makes console-report behavior harder to test independently.

### Proposed change

Move the optional enable-report provider handling into ServiceHandler, have GCReportPlugin delegate service registration through it for both Develocity and non-Develocity builds, and remove the unused ConsoleReport wrapper if no longer needed. Preserve report output and lifecycle behavior.

### Notes

This keeps GCReportPlugin as the composition root while isolating Gradle service registration in an infrastructure adapter. Core parsing, histogram, and report behavior remain untouched.

Fixes #13

## Changes

- `gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/GCReportPlugin.kt`
- `gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/ServiceHandler.kt`
- `gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportServiceRegistrationTest.kt`

## Verification

- `./gradlew ktlintCheck`
- `./gradlew test`
