### PR TITLE
fix: develocity plugin leaks onto consumers' classpath: use compileonly

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -11,8 +11,9 @@ group = "io.github.cdsap"
 version = "0.1.0"
 
 dependencies {
-    implementation(libs.develocity)
+    compileOnly(libs.develocity)
     implementation(libs.picnic)
+    testImplementation(libs.develocity)
     testImplementation(platform(libs.junit))
     testImplementation(libs.ktor.client.cio)
     testImplementation(libs.gson)
@@ -23,6 +24,17 @@ dependencies {
 tasks.test {
     useJUnitPlatform()
 }
+
+// TestKit uses an isolated plugin classpath; include Develocity there so optional integration
+// tests can load DevelocityConfiguration without publishing it as a consumer runtime dependency.
+tasks.named<PluginUnderTestMetadata>("pluginUnderTestMetadata") {
+    pluginClasspath.from(
+        configurations.compileClasspath.map { classpath ->
+            classpath.filter { it.name.startsWith("develocity-gradle-plugin") }
+        },
+    )
+}
+
 gradlePlugin {
     website = "https://github.com/cdsap/GCReport"
     vcsUrl = "https://github.com/cdsap/GCReport.git"

--- a/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/GCReportPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/GCReportPlugin.kt
@@ -1,7 +1,7 @@
 package io.github.cdsap.gcreport.plugin
 
-import com.gradle.develocity.agent.gradle.DevelocityConfiguration
-import io.github.cdsap.gcreport.plugin.report.DevelocityReport
+import io.github.cdsap.gcreport.plugin.report.DevelocityPresence
+import io.github.cdsap.gcreport.plugin.report.DevelocitySupport
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.provider.Property
@@ -13,13 +13,13 @@ import org.gradle.kotlin.dsl.create
 class GCReportPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.extensions.create<GCReportExtension>("gcReport")
-        val develocityConfiguration =
-            target.gradle.rootProject.extensions.findByType(DevelocityConfiguration::class.java)
+        // Resolve Develocity without hard-referencing its types (compileOnly; may be absent).
+        val develocityExtension = DevelocityPresence.findExtension(target.gradle.rootProject)
         target.gradle.rootProject {
             val extension = target.extensions.getByName("gcReport") as GCReportExtension
-            if (develocityConfiguration != null) {
+            if (develocityExtension != null) {
                 createService(target, extension, extension.enableConsoleLog)
-                DevelocityReport(develocityConfiguration, extension).report()
+                DevelocitySupport.register(develocityExtension, extension)
             } else {
                 createService(target, extension)
             }

--- a/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/report/DevelocityPresence.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/report/DevelocityPresence.kt
@@ -1,0 +1,21 @@
+package io.github.cdsap.gcreport.plugin.report
+
+import org.gradle.api.Project
+
+/** Finds a Develocity extension without referencing Develocity API types. */
+internal object DevelocityPresence {
+    private const val CONFIGURATION_CLASS =
+        "com.gradle.develocity.agent.gradle.DevelocityConfiguration"
+
+    fun findExtension(project: Project): Any? {
+        val bySchema =
+            project.extensions.extensionsSchema.elements
+                .firstOrNull { it.publicType.concreteClass.name == CONFIGURATION_CLASS }
+                ?.let { project.extensions.findByName(it.name) }
+        if (bySchema != null) {
+            return bySchema
+        }
+        return project.extensions.findByName("develocity")
+            ?: project.extensions.findByName("gradleEnterprise")
+    }
+}

--- a/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/report/DevelocitySupport.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/report/DevelocitySupport.kt
@@ -1,0 +1,14 @@
+package io.github.cdsap.gcreport.plugin.report
+
+import com.gradle.develocity.agent.gradle.DevelocityConfiguration
+import io.github.cdsap.gcreport.plugin.GCReportExtension
+
+/** Bridges to Develocity types that are only available when the Develocity plugin is applied. */
+internal object DevelocitySupport {
+    fun register(
+        develocityExtension: Any,
+        extension: GCReportExtension,
+    ) {
+        DevelocityReport(develocityExtension as DevelocityConfiguration, extension).report()
+    }
+}

--- a/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportPluginWithDevelocityTest.kt
+++ b/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportPluginWithDevelocityTest.kt
@@ -279,4 +279,53 @@ class GCReportPluginWithDevelocityTest {
         assertTrue(gcLogs.any { it.name == "gc-$gcFile-total-collections" })
         assertTrue(gcLogs.any { it.name == "gc-$gcFile-histogram" })
     }
+
+    @Test
+    fun `plugin applies alongside Develocity with compileOnly classpath`() {
+        val gcLog = "${testProjectDir.absolutePath}/gc.log"
+        File(testProjectDir, "gradle.properties").writeText(
+            """
+            org.gradle.jvmargs=-Xlog:gc*:file=$gcLog
+            """.trimIndent(),
+        )
+        File(testProjectDir, "settings.gradle.kts").writeText(
+            """
+            pluginManagement {
+                repositories {
+                    gradlePluginPortal()
+                    mavenCentral()
+                }
+            }
+            plugins {
+                id("com.gradle.develocity") version "3.19.1"
+            }
+            develocity {
+                buildScan {
+                    publishing.onlyIf { false }
+                }
+            }
+            """.trimIndent(),
+        )
+        File(testProjectDir, "build.gradle.kts").writeText(
+            """
+            plugins {
+                id("io.github.cdsap.gcreport")
+                java
+            }
+
+            gcReport {
+                logs.set(listOf("$gcLog"))
+            }
+            """,
+        )
+
+        val result =
+            GradleRunner.create()
+                .withProjectDir(testProjectDir)
+                .withArguments("tasks", "--stacktrace")
+                .withPluginClasspath()
+                .build()
+
+        assertTrue(result.output.contains("BUILD SUCCESSFUL"))
+    }
 }

--- a/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GradlePluginBuildConfigTest.kt
+++ b/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GradlePluginBuildConfigTest.kt
@@ -1,5 +1,6 @@
 package io.github.cdsap.gcreport.plugin
 
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -24,6 +25,39 @@ class GradlePluginBuildConfigTest {
         assertTrue(
             versionCatalogContents.contains("junit-platform-launcher"),
             "gradle/libs.versions.toml must declare junit-platform-launcher",
+        )
+    }
+
+    @Test
+    fun `develocity is compileOnly so it is not published as a runtime dependency`() {
+        val buildGradleContents = File("build.gradle.kts").canonicalFile.readText()
+
+        assertTrue(
+            buildGradleContents.contains("compileOnly(libs.develocity)"),
+            "build.gradle.kts must declare develocity as compileOnly",
+        )
+        assertTrue(
+            buildGradleContents.contains("testImplementation(libs.develocity)"),
+            "build.gradle.kts must declare develocity on the test classpath",
+        )
+        assertFalse(
+            buildGradleContents.contains("implementation(libs.develocity)"),
+            "build.gradle.kts must not declare develocity as implementation (leaks onto consumers)",
+        )
+        assertTrue(
+            buildGradleContents.contains("pluginUnderTestMetadata"),
+            "build.gradle.kts must keep Develocity on the TestKit plugin classpath via pluginUnderTestMetadata",
+        )
+    }
+
+    @Test
+    fun `GCReportPlugin does not hard-reference DevelocityConfiguration`() {
+        val pluginSource =
+            File("src/main/kotlin/io/github/cdsap/gcreport/plugin/GCReportPlugin.kt").canonicalFile
+
+        assertFalse(
+            pluginSource.readText().contains("DevelocityConfiguration"),
+            "GCReportPlugin must not reference DevelocityConfiguration so it can load without Develocity on the classpath",
         )
     }
 }


### PR DESCRIPTION
## Summary

### Problem

`gradle-plugin/build.gradle.kts:14` declares the Develocity Gradle plugin as `implementation`:

```kotlin
implementation(libs.develocity)
```

Because it is an `implementation` dependency, it is published as a **runtime** dependency of this plugin. Verified in the generated POM (`./gradlew :gradle-plugin:generatePomFileForPluginMavenPublication`):

```xml
<dependency>
  <groupId>com.gradle</groupId>
  <artifactId>develocity-gradle-plugin</artifactId>
  <version>3.19.1</version>
  <scope>runtime</scope>
</dependency>
```

Fixes #14

## Changes

- `gradle-plugin/build.gradle.kts`
- `gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/GCReportPlugin.kt`
- `gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/report/DevelocityPresence.kt`
- `gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/report/DevelocitySupport.kt`
- `gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportPluginWithDevelocityTest.kt`
- `gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GradlePluginBuildConfigTest.kt`

## Verification

- `./gradlew ktlintCheck`
- `./gradlew test`
