### PR TITLE
fix: no java toolchain: published bytecode target depends on the build m

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ Bucket,Occurrences
 4.92-End,1
 ```
 
+### Compatibility
+* Minimum Java version: **11**. Published plugin bytecode is pinned with `jvmToolchain(11)`, so the class-file target does not depend on which JDK runs the build.
+
 ### Considerations
 * Supported GC types:
     - G1

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -10,6 +10,10 @@ plugins {
 group = "io.github.cdsap"
 version = "0.1.0"
 
+kotlin {
+    jvmToolchain(11)
+}
+
 dependencies {
     implementation(libs.develocity)
     implementation(libs.picnic)

--- a/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GradlePluginBuildConfigTest.kt
+++ b/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GradlePluginBuildConfigTest.kt
@@ -1,7 +1,9 @@
 package io.github.cdsap.gcreport.plugin
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import java.io.DataInputStream
 import java.io.File
 
 class GradlePluginBuildConfigTest {
@@ -25,5 +27,42 @@ class GradlePluginBuildConfigTest {
             versionCatalogContents.contains("junit-platform-launcher"),
             "gradle/libs.versions.toml must declare junit-platform-launcher",
         )
+    }
+
+    @Test
+    fun `gradle plugin build pins jvm toolchain to java 11`() {
+        val buildGradleContents = File("build.gradle.kts").canonicalFile.readText()
+
+        assertTrue(
+            buildGradleContents.contains("jvmToolchain(11)"),
+            "build.gradle.kts must pin kotlin jvmToolchain(11) so published bytecode is stable",
+        )
+    }
+
+    @Test
+    fun `compiled plugin classes target java 11 bytecode`() {
+        val classFile =
+            File("build/classes/kotlin/main/io/github/cdsap/gcreport/plugin/GCReportPlugin.class")
+                .canonicalFile
+
+        assertTrue(classFile.isFile, "Expected compiled class at ${classFile.path}")
+        assertEquals(
+            JAVA_11_MAJOR_VERSION,
+            classFileMajorVersion(classFile),
+            "Published plugin bytecode must target Java 11 (major version $JAVA_11_MAJOR_VERSION)",
+        )
+    }
+
+    private fun classFileMajorVersion(classFile: File): Int =
+        DataInputStream(classFile.inputStream().buffered()).use { input ->
+            val magic = input.readInt()
+            assertEquals(CLASS_FILE_MAGIC, magic, "File is not a valid JVM class file: ${classFile.path}")
+            input.readUnsignedShort() // minor version
+            input.readUnsignedShort() // major version
+        }
+
+    private companion object {
+        const val CLASS_FILE_MAGIC = -0x35014542 // 0xCAFEBABE
+        const val JAVA_11_MAJOR_VERSION = 55
     }
 }


### PR DESCRIPTION
## Summary

### Problem

Neither the root nor the `gradle-plugin` build script configures a Java toolchain or `targetCompatibility`. The bytecode target is therefore whatever JDK happens to run the build.

Verified:

- Locally (Zulu JDK 21) — `javap -v` on the compiled plugin class reports `major version: 65`, i.e. **Java 21** bytecode.
- CI (`.github/workflows/build.yaml`) pins `java-version: 17`, so CI produces **Java 17** bytecode.

Fixes #15

## Changes

- `README.md`
- `gradle-plugin/build.gradle.kts`
- `gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GradlePluginBuildConfigTest.kt`

## Verification

- `./gradlew ktlintCheck`
- `./gradlew test`
