### PR TITLE
fix: published artifactid is the generic 'gradle-plugin'

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -10,6 +10,15 @@ plugins {
 group = "io.github.cdsap"
 version = "0.1.0"
 
+// Project directory is gradle-plugin; override so Maven coordinates are descriptive.
+publishing {
+    publications {
+        create<MavenPublication>("pluginMaven") {
+            artifactId = "gcreport-gradle-plugin"
+        }
+    }
+}
+
 dependencies {
     implementation(libs.develocity)
     implementation(libs.picnic)
@@ -22,6 +31,7 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+    dependsOn(tasks.named("generatePomFileForPluginMavenPublication"))
 }
 gradlePlugin {
     website = "https://github.com/cdsap/GCReport"

--- a/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GradlePluginBuildConfigTest.kt
+++ b/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GradlePluginBuildConfigTest.kt
@@ -26,4 +26,38 @@ class GradlePluginBuildConfigTest {
             "gradle/libs.versions.toml must declare junit-platform-launcher",
         )
     }
+
+    @Test
+    fun `gradle plugin Maven publication uses descriptive artifactId`() {
+        val buildGradleContents = File("build.gradle.kts").canonicalFile.readText()
+
+        assertTrue(
+            buildGradleContents.contains("""create<MavenPublication>("pluginMaven")"""),
+            "build.gradle.kts must configure the pluginMaven publication",
+        )
+        assertTrue(
+            buildGradleContents.contains("""artifactId = "gcreport-gradle-plugin""""),
+            "pluginMaven publication must use descriptive artifactId gcreport-gradle-plugin",
+        )
+    }
+
+    @Test
+    fun `generated pluginMaven POM has descriptive artifactId`() {
+        val pomFile = File("build/publications/pluginMaven/pom-default.xml").canonicalFile
+        assertTrue(
+            pomFile.isFile,
+            "Expected generated POM at ${pomFile.path}; run generatePomFileForPluginMavenPublication first",
+        )
+
+        val primaryArtifactId =
+            Regex("""<artifactId>([^<]+)</artifactId>""")
+                .find(pomFile.readText())
+                ?.groupValues
+                ?.get(1)
+
+        assertTrue(
+            primaryArtifactId == "gcreport-gradle-plugin",
+            "Expected primary artifactId gcreport-gradle-plugin but was $primaryArtifactId",
+        )
+    }
 }


### PR DESCRIPTION
## Summary

### Problem

The published Maven coordinates are derived from the subproject directory name, so the plugin publishes as:

```
io.github.cdsap:gradle-plugin:0.1.0
```

Verified in the generated POM: `<artifactId>gradle-plugin</artifactId>`.

Fixes #17

## Changes

- `gradle-plugin/build.gradle.kts`
- `gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GradlePluginBuildConfigTest.kt`

## Verification

- `./gradlew ktlintCheck`
- `./gradlew test`
