### PR TITLE
fix: add a project gradle.properties: build cache, configuration cache,

### DIFF
--- a/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GradlePropertiesTest.kt
+++ b/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GradlePropertiesTest.kt
@@ -1,0 +1,29 @@
+package io.github.cdsap.gcreport.plugin
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.util.Properties
+
+class GradlePropertiesTest {
+    @Test
+    fun `project gradle properties enable cache parallel and jvmargs`() {
+        val gradleProperties = File("../gradle.properties").canonicalFile
+
+        assertTrue(gradleProperties.isFile, "gradle.properties should exist at ${gradleProperties.path}")
+
+        val properties =
+            Properties().apply {
+                gradleProperties.inputStream().use { load(it) }
+            }
+
+        assertEquals("true", properties.getProperty("org.gradle.caching"))
+        assertEquals("true", properties.getProperty("org.gradle.configuration-cache"))
+        assertEquals("true", properties.getProperty("org.gradle.parallel"))
+        assertEquals(
+            "-Xmx2g -XX:MaxMetaspaceSize=768m",
+            properties.getProperty("org.gradle.jvmargs"),
+        )
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.caching=true
+org.gradle.configuration-cache=true
+org.gradle.parallel=true
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=768m


### PR DESCRIPTION
## Summary

### Problem

The repository has **no `gradle.properties`**, so none of the standard build performance or correctness flags are set for anyone who clones it.

This is easy to miss locally: while auditing, a clean `./gradlew build` showed `FROM-CACHE` task outcomes and parallel execution — but those came from `~/.gradle/gradle.properties` on the developer machine, **not** from the repo. CI, running on a fresh GitHub Actions runner, gets none of them.

Fixes #20

## Changes

- `gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GradlePropertiesTest.kt`
- `gradle.properties`

## Verification

- `./gradlew ktlintCheck`
- `./gradlew test`
