### PR TITLE
fix: root project applies kotlin-jvm but has no sources

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,3 @@
 plugins {
-    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.jvm) apply false
 }

--- a/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/RootProjectBuildConfigTest.kt
+++ b/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/RootProjectBuildConfigTest.kt
@@ -1,0 +1,29 @@
+package io.github.cdsap.gcreport.plugin
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class RootProjectBuildConfigTest {
+    @Test
+    fun `root project declares kotlin jvm plugin without applying it`() {
+        val rootBuildGradle = File("../build.gradle.kts").canonicalFile
+        val rootBuildGradleContents = rootBuildGradle.readText()
+
+        assertTrue(
+            rootBuildGradleContents.contains("alias(libs.plugins.kotlin.jvm) apply false"),
+            "root build.gradle.kts must declare kotlin-jvm with apply false so the aggregator is not a code module",
+        )
+    }
+
+    @Test
+    fun `root project has no source directory`() {
+        val rootSrc = File("../src").canonicalFile
+
+        assertFalse(
+            rootSrc.exists(),
+            "root project should remain a pure aggregator without a src/ directory",
+        )
+    }
+}


### PR DESCRIPTION
## Summary

### Problem

The root `build.gradle.kts` is:

```kotlin
plugins {
    alias(libs.plugins.kotlin.jvm)
}
```

The root project has **no `src/` directory** (verified). Applying the Kotlin JVM plugin to it creates a full Java/Kotlin compilation and jar pipeline for a project with nothing to compile, and produces an empty `build/libs` jar.

Fixes #21

## Changes

- `build.gradle.kts`
- `gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/RootProjectBuildConfigTest.kt`

## Verification

- `./gradlew ktlintCheck`
- `./gradlew test`
