### PR TITLE
fix: enable stricter plugin validation (validateplugins.enablestricterva

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -23,6 +23,10 @@ dependencies {
 tasks.test {
     useJUnitPlatform()
 }
+
+tasks.validatePlugins {
+    enableStricterValidation = true
+}
 gradlePlugin {
     website = "https://github.com/cdsap/GCReport"
     vcsUrl = "https://github.com/cdsap/GCReport.git"

--- a/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GradlePluginBuildConfigTest.kt
+++ b/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GradlePluginBuildConfigTest.kt
@@ -26,4 +26,19 @@ class GradlePluginBuildConfigTest {
             "gradle/libs.versions.toml must declare junit-platform-launcher",
         )
     }
+
+    @Test
+    fun `validatePlugins enables stricter validation`() {
+        val buildGradle = File("build.gradle.kts").canonicalFile
+        val buildGradleContents = buildGradle.readText()
+
+        assertTrue(
+            buildGradleContents.contains("tasks.validatePlugins"),
+            "build.gradle.kts must configure the validatePlugins task",
+        )
+        assertTrue(
+            buildGradleContents.contains("enableStricterValidation = true"),
+            "build.gradle.kts must enable validatePlugins.enableStricterValidation",
+        )
+    }
 }


### PR DESCRIPTION
## Summary

### Problem

The `java-gradle-plugin` plugin contributes a `validatePlugins` task, which currently runs with default (lenient) settings. Gradle offers a stricter mode that plugin authors are encouraged to enable.

Fixes #22

## Changes

- `gradle-plugin/build.gradle.kts`
- `gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GradlePluginBuildConfigTest.kt`

## Verification

- `./gradlew ktlintCheck`
- `./gradlew test`
