### PR TITLE
fix: ci: reduce workflow permissions to least privilege

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,10 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
       checks: write
-      security-events: write
 
     timeout-minutes: 60
 

--- a/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/BuildWorkflowPermissionsTest.kt
+++ b/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/BuildWorkflowPermissionsTest.kt
@@ -1,0 +1,67 @@
+package io.github.cdsap.gcreport.plugin
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class BuildWorkflowPermissionsTest {
+    @Test
+    fun `build workflow uses least privilege permissions`() {
+        val workflow = File("../.github/workflows/build.yaml").canonicalFile
+        assertTrue(workflow.isFile, "Build workflow should exist at ${workflow.path}")
+
+        val workflowText = workflow.readText()
+        val permissions = permissionsBlock(workflowText)
+        assertEquals(
+            mapOf(
+                "contents" to "read",
+                "checks" to "write",
+            ),
+            permissions,
+            "Build job should grant only contents: read and checks: write",
+        )
+
+        assertFalse(
+            workflowText.contains("pull-requests:"),
+            "Build workflow should not request pull-requests permissions",
+        )
+        assertFalse(
+            workflowText.contains("security-events:"),
+            "Build workflow should not request security-events permissions",
+        )
+        assertFalse(
+            workflowText.contains("contents: write"),
+            "Build workflow should not grant contents: write",
+        )
+        assertTrue(
+            workflowText.contains("mikepenz/action-junit-report"),
+            "Build workflow should still publish a JUnit report check",
+        )
+    }
+
+    private fun permissionsBlock(workflowText: String): Map<String, String> {
+        val lines = workflowText.lines()
+        val startIndex =
+            lines.indexOfFirst { it.trim() == "permissions:" }.also {
+                assertTrue(it >= 0, "Build workflow should declare a permissions block")
+            }
+
+        val permissionsIndent = lines[startIndex].takeWhile { it == ' ' }.length
+        val entries = linkedMapOf<String, String>()
+        for (line in lines.drop(startIndex + 1)) {
+            val indent = line.takeWhile { it == ' ' }.length
+            if (line.isBlank()) {
+                continue
+            }
+            if (indent <= permissionsIndent) {
+                break
+            }
+            val match = Regex("""(\S+):\s*(\S+)""").matchEntire(line.trim())
+            assertTrue(match != null, "Unexpected permissions line: $line")
+            entries[match!!.groupValues[1]] = match.groupValues[2]
+        }
+        return entries
+    }
+}


### PR DESCRIPTION
## Summary

### Problem

The single build-and-test job in `.github/workflows/build.yaml` requests broad write permissions:

```yaml
permissions:
  contents: write
  pull-requests: write
  checks: write
  security-events: write
```

The job checks out the code, runs `ktlintCheck` and `test`, uploads test artifacts, and publishes a JUnit check summary. Of these, only `checks: write` (for `mikepenz/action-junit-report`) is actually needed beyond read access.

Fixes #26

## Changes

- `.github/workflows/build.yaml`
- `gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/BuildWorkflowPermissionsTest.kt`

## Verification

- `./gradlew ktlintCheck`
- `./gradlew test`
