### PR TITLE
fix: ci: add a gradle and jdk compatibility matrix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,8 +8,14 @@ on:
 
 jobs:
   build:
-    name: "Build and test"
+    name: "Build and test (JDK ${{ matrix.java }}, Gradle ${{ matrix.gradle }})"
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ 17, 21 ]
+        gradle: [ '8.9', '8.12.1', '8.14.3' ]
 
     permissions:
       contents: write
@@ -23,18 +29,18 @@ jobs:
       - name: Checkout
 
         uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 17
+          java-version: ${{ matrix.java }}
 
       - name: Ktlinkt
         run: ./gradlew ktlintCheck
 
       - name: test
         id: test
-        run: ./gradlew test
+        run: ./gradlew test -DtestGradleVersion=${{ matrix.gradle }}
         env:
           GE_API_KEY: ${{ secrets.GE_API }}
           GE_URL: ${{ secrets.GE_URL }}
@@ -43,7 +49,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: junit-test-reports
+          name: junit-test-reports-jdk${{ matrix.java }}-gradle${{ matrix.gradle }}
           path: |
             **/build/test-results/**/*.xml
             **/build/reports/tests/**
@@ -55,5 +61,5 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         with:
           report_paths: '**/build/test-results/**/TEST-*.xml'
-          check_name: JUnit Test Report
+          check_name: JUnit Test Report (JDK ${{ matrix.java }}, Gradle ${{ matrix.gradle }})
           fail_on_failure: false

--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ Bucket,Occurrences
 4.92-End,1
 ```
 
+### Compatibility
+* **Gradle:** **8.9+** (CI exercises **8.9**, **8.12.1**, and **8.14.3**). The lower bound matches the Gradle release that relocated the internal `serviceOf` API this plugin currently uses.
+* **Java:** CI tests on **Java 17** and **21** (Zulu). These are the JDKs used to run Gradle and produce the GC logs the plugin parses.
+* **GC collectors / log formats:** Unified JVM logging (`-Xlog:gc*`) for **G1** and **Parallel**.
+
 ### Considerations
 * Supported GC types:
     - G1

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -22,6 +22,13 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+    // Forward CI/local -DtestGradleVersion (or TEST_GRADLE_VERSION) into TestKit runners.
+    val testGradleVersion =
+        providers.systemProperty("testGradleVersion")
+            .orElse(providers.environmentVariable("TEST_GRADLE_VERSION"))
+    if (testGradleVersion.isPresent) {
+        systemProperty("testGradleVersion", testGradleVersion.get())
+    }
 }
 gradlePlugin {
     website = "https://github.com/cdsap/GCReport"

--- a/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/CompatibilityMatrixTest.kt
+++ b/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/CompatibilityMatrixTest.kt
@@ -1,0 +1,79 @@
+package io.github.cdsap.gcreport.plugin
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class CompatibilityMatrixTest {
+    @Test
+    fun `ci workflow exercises the documented java and gradle compatibility matrix`() {
+        val workflow = File("../.github/workflows/build.yaml").canonicalFile
+        assertTrue(workflow.isFile, "CI workflow should exist at ${workflow.path}")
+
+        val workflowText = workflow.readText()
+        assertTrue(
+            workflowText.contains("fail-fast: false"),
+            "Compatibility matrix should keep other cells running when one fails",
+        )
+        assertTrue(
+            workflowText.contains("java: [ 17, 21 ]") ||
+                workflowText.contains("java: [17, 21]"),
+            "CI should test JDK 17 and 21 boundaries",
+        )
+        for (gradle in SUPPORTED_GRADLE_VERSIONS) {
+            assertTrue(
+                workflowText.contains("'$gradle'") || workflowText.contains("\"$gradle\""),
+                "CI matrix should include Gradle $gradle",
+            )
+        }
+        assertTrue(
+            workflowText.contains("testGradleVersion=\${{ matrix.gradle }}") ||
+                workflowText.contains("TEST_GRADLE_VERSION: \${{ matrix.gradle }}"),
+            "CI must drive TestKit Gradle version from the matrix",
+        )
+        assertTrue(
+            workflowText.contains("java-version: \${{ matrix.java }}"),
+            "CI must install the matrix JDK",
+        )
+        assertTrue(
+            workflowText.contains("junit-test-reports-jdk\${{ matrix.java }}-gradle\${{ matrix.gradle }}") ||
+                workflowText.contains("name: junit-test-reports-\${{ matrix.java }}-\${{ matrix.gradle }}"),
+            "Matrix builds need unique JUnit artifact names",
+        )
+    }
+
+    @Test
+    fun `readme documents supported gradle and java ranges`() {
+        val readme = File("../README.md").canonicalFile
+        assertTrue(readme.isFile, "README should exist at ${readme.path}")
+
+        val readmeText = readme.readText()
+        assertTrue(
+            readmeText.contains("### Compatibility"),
+            "README must include a Compatibility section",
+        )
+        assertTrue(
+            Regex("""Gradle[:\s*]*\**${Regex.escape(SUPPORTED_GRADLE_VERSIONS.first())}\+\**""")
+                .containsMatchIn(readmeText),
+            "README must document the minimum supported Gradle version",
+        )
+        assertTrue(
+            Regex("""Java[:\s*]*\**17\**\s+and\s+\**21\**""")
+                .containsMatchIn(readmeText),
+            "README must document the tested Java versions",
+        )
+    }
+
+    @Test
+    fun `gradle plugin build forwards testGradleVersion into TestKit tests`() {
+        val buildGradle = File("build.gradle.kts").canonicalFile.readText()
+        assertTrue(
+            buildGradle.contains("testGradleVersion"),
+            "build.gradle.kts must forward testGradleVersion to the test JVM for TestKit",
+        )
+    }
+
+    companion object {
+        val SUPPORTED_GRADLE_VERSIONS = listOf("8.9", "8.12.1", "8.14.3")
+    }
+}

--- a/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportPluginWithDevelocityTest.kt
+++ b/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportPluginWithDevelocityTest.kt
@@ -11,7 +11,6 @@ import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
-import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
@@ -75,7 +74,7 @@ class GCReportPluginWithDevelocityTest {
             """,
         )
 
-        GradleRunner.create()
+        GradleTestKit.runner()
             .withProjectDir(testProjectDir)
             .withArguments("tasks")
             .withPluginClasspath()
@@ -161,7 +160,7 @@ class GCReportPluginWithDevelocityTest {
             """,
         )
 
-        GradleRunner.create()
+        GradleTestKit.runner()
             .withProjectDir(testProjectDir)
             .withArguments("tasks")
             .withPluginClasspath()
@@ -249,7 +248,7 @@ class GCReportPluginWithDevelocityTest {
             """,
         )
 
-        GradleRunner.create()
+        GradleTestKit.runner()
             .withProjectDir(testProjectDir)
             .withArguments("tasks")
             .withPluginClasspath()

--- a/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportPluginWithoutDevelocityTest.kt
+++ b/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportPluginWithoutDevelocityTest.kt
@@ -1,6 +1,5 @@
 package io.github.cdsap.gcreport.plugin
 
-import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -36,7 +35,7 @@ class GCReportPluginWithoutDevelocityTest {
         )
 
         val result =
-            GradleRunner.create()
+            GradleTestKit.runner()
                 .withProjectDir(testProjectDir)
                 .withArguments("tasks")
                 .withPluginClasspath()
@@ -74,7 +73,7 @@ class GCReportPluginWithoutDevelocityTest {
         )
 
         val result =
-            GradleRunner.create()
+            GradleTestKit.runner()
                 .withProjectDir(testProjectDir)
                 .withArguments("tasks")
                 .withPluginClasspath()
@@ -114,7 +113,7 @@ class GCReportPluginWithoutDevelocityTest {
         )
 
         val result =
-            GradleRunner.create()
+            GradleTestKit.runner()
                 .withProjectDir(testProjectDir)
                 .withArguments("tasks")
                 .withPluginClasspath()
@@ -155,7 +154,7 @@ class GCReportPluginWithoutDevelocityTest {
         )
 
         val result =
-            GradleRunner.create()
+            GradleTestKit.runner()
                 .withProjectDir(testProjectDir)
                 .withArguments("tasks")
                 .withPluginClasspath()
@@ -216,7 +215,7 @@ class GCReportPluginWithoutDevelocityTest {
         kotlinFile.writeText(kotlinClassContent)
 
         val result =
-            GradleRunner.create()
+            GradleTestKit.runner()
                 .withProjectDir(testProjectDir)
                 .withArguments("assemble")
                 .withPluginClasspath()
@@ -260,14 +259,14 @@ class GCReportPluginWithoutDevelocityTest {
             """,
         )
 
-        GradleRunner.create()
+        GradleTestKit.runner()
             .withProjectDir(testProjectDir)
             .withArguments("clean", "assemble", "--configuration-cache")
             .withPluginClasspath()
             .build()
 
         val withConfigurationCache =
-            GradleRunner.create()
+            GradleTestKit.runner()
                 .withProjectDir(testProjectDir)
                 .withArguments("clean", "assemble", "--configuration-cache")
                 .withPluginClasspath()

--- a/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportServiceRegistrationTest.kt
+++ b/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportServiceRegistrationTest.kt
@@ -1,6 +1,5 @@
 package io.github.cdsap.gcreport.plugin
 
-import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -71,7 +70,7 @@ class GCReportServiceRegistrationTest {
         )
 
         val result =
-            GradleRunner.create()
+            GradleTestKit.runner()
                 .withProjectDir(testProjectDir)
                 .withArguments("tasks")
                 .withPluginClasspath()
@@ -122,7 +121,7 @@ class GCReportServiceRegistrationTest {
         )
 
         val result =
-            GradleRunner.create()
+            GradleTestKit.runner()
                 .withProjectDir(testProjectDir)
                 .withArguments("tasks")
                 .withPluginClasspath()

--- a/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GradleTestKit.kt
+++ b/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GradleTestKit.kt
@@ -1,0 +1,17 @@
+package io.github.cdsap.gcreport.plugin
+
+import org.gradle.testkit.runner.GradleRunner
+
+internal object GradleTestKit {
+    fun runner(): GradleRunner {
+        val runner = GradleRunner.create()
+        val version =
+            System.getProperty("testGradleVersion")
+                ?.takeIf { it.isNotBlank() }
+                ?: System.getenv("TEST_GRADLE_VERSION")?.takeIf { it.isNotBlank() }
+        if (version != null) {
+            runner.withGradleVersion(version)
+        }
+        return runner
+    }
+}

--- a/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GradleTestKitTest.kt
+++ b/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GradleTestKitTest.kt
@@ -1,0 +1,46 @@
+package io.github.cdsap.gcreport.plugin
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class GradleTestKitTest {
+    @Test
+    fun `functional tests drive GradleRunner through GradleTestKit`() {
+        val testSources =
+            File("src/test/java/io/github/cdsap/gcreport/plugin")
+                .canonicalFile
+                .walkTopDown()
+                .filter { it.isFile && it.extension == "kt" }
+                .filter {
+                    it.name in
+                        setOf(
+                            "GCReportPluginWithoutDevelocityTest.kt",
+                            "GCReportPluginWithDevelocityTest.kt",
+                            "GCReportServiceRegistrationTest.kt",
+                        )
+                }
+                .toList()
+
+        assertTrue(testSources.size == 3, "Expected the three TestKit functional test classes")
+
+        testSources.forEach { source ->
+            val text = source.readText()
+            assertTrue(
+                text.contains("GradleTestKit.runner()"),
+                "${source.name} must obtain runners via GradleTestKit.runner()",
+            )
+            assertFalse(
+                text.contains("GradleRunner.create()"),
+                "${source.name} must not call GradleRunner.create() directly",
+            )
+        }
+
+        val helper = File("src/test/java/io/github/cdsap/gcreport/plugin/GradleTestKit.kt").canonicalFile
+        assertTrue(helper.isFile, "GradleTestKit helper should exist")
+        val helperText = helper.readText()
+        assertTrue(helperText.contains("withGradleVersion"))
+        assertTrue(helperText.contains("testGradleVersion"))
+    }
+}


### PR DESCRIPTION
## Summary

### Problem

CI runs exactly one configuration: `ubuntu-latest` with JDK 17 and whatever Gradle version the wrapper pins (currently 8.12.1). This plugin declares no supported Gradle or Java range and tests none.

Fixes #28

## Changes

- `.github/workflows/build.yaml`
- `README.md`
- `gradle-plugin/build.gradle.kts`
- `gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/CompatibilityMatrixTest.kt`
- `gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportPluginWithDevelocityTest.kt`
- `gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportPluginWithoutDevelocityTest.kt`
- `gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportServiceRegistrationTest.kt`
- `gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GradleTestKit.kt`
- `gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GradleTestKitTest.kt`

## Verification

- `./gradlew ktlintCheck`
- `./gradlew test`
