### PR TITLE
fix: ci: fix 'ktlinkt' step name typo

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,7 @@ jobs:
           distribution: 'zulu'
           java-version: 17
 
-      - name: Ktlinkt
+      - name: Ktlint
         run: ./gradlew ktlintCheck
 
       - name: test

--- a/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/BuildWorkflowConfigTest.kt
+++ b/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/BuildWorkflowConfigTest.kt
@@ -1,0 +1,24 @@
+package io.github.cdsap.gcreport.plugin
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class BuildWorkflowConfigTest {
+    @Test
+    fun `build workflow uses correctly spelled Ktlint step name`() {
+        val workflow = File("../.github/workflows/build.yaml").canonicalFile
+        assertTrue(workflow.isFile, "Build workflow should exist at ${workflow.path}")
+
+        val contents = workflow.readText()
+        assertFalse(
+            contents.contains("name: Ktlinkt"),
+            "Build workflow must not use the misspelled step name Ktlinkt",
+        )
+        assertTrue(
+            contents.contains("name: Ktlint"),
+            "Build workflow should name the ktlintCheck step Ktlint",
+        )
+    }
+}


### PR DESCRIPTION
## Summary

### Problem

Step name typo in `.github/workflows/build.yaml`:

```yaml
- name: Ktlinkt
  run: ./gradlew ktlintCheck
```

"Ktlinkt" should be "Ktlint".

Fixes #29

## Changes

- `.github/workflows/build.yaml`
- `gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/BuildWorkflowConfigTest.kt`

## Verification

- `./gradlew ktlintCheck`
- `./gradlew test`
