### PR TITLE
fix: use managed lazy properties for buildservice parameters and the ext

### DIFF
--- a/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/GCReportExtension.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/GCReportExtension.kt
@@ -1,13 +1,12 @@
 package io.github.cdsap.gcreport.plugin
 
 import io.github.cdsap.gcreport.plugin.model.Bucket
-import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 
-open class GCReportExtension(objects: ObjectFactory) {
-    val logs: ListProperty<String> = objects.listProperty(String::class.java)
-    val histogramEnabled: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
-    val histogramBucket: Property<Bucket> = objects.property(Bucket::class.java).convention(Bucket.FreedmanDiaconis)
-    val enableConsoleLog: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
+abstract class GCReportExtension {
+    abstract val logs: ListProperty<String>
+    abstract val histogramEnabled: Property<Boolean>
+    abstract val histogramBucket: Property<Bucket>
+    abstract val enableConsoleLog: Property<Boolean>
 }

--- a/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/GCReportPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/GCReportPlugin.kt
@@ -1,6 +1,7 @@
 package io.github.cdsap.gcreport.plugin
 
 import com.gradle.develocity.agent.gradle.DevelocityConfiguration
+import io.github.cdsap.gcreport.plugin.model.Bucket
 import io.github.cdsap.gcreport.plugin.report.DevelocityReport
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -8,11 +9,15 @@ import org.gradle.kotlin.dsl.create
 
 class GCReportPlugin : Plugin<Project> {
     override fun apply(target: Project) {
-        target.extensions.create<GCReportExtension>("gcReport")
+        val extension =
+            target.extensions.create<GCReportExtension>("gcReport").apply {
+                histogramEnabled.convention(false)
+                histogramBucket.convention(Bucket.FreedmanDiaconis)
+                enableConsoleLog.convention(false)
+            }
         val develocityConfiguration =
             target.gradle.rootProject.extensions.findByType(DevelocityConfiguration::class.java)
         target.gradle.rootProject {
-            val extension = target.extensions.getByName("gcReport") as GCReportExtension
             if (develocityConfiguration != null) {
                 ServiceHandler(target, extension, extension.enableConsoleLog).createService()
                 DevelocityReport(develocityConfiguration, extension).report()

--- a/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/GCReportService.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/GCReportService.kt
@@ -8,8 +8,9 @@ import io.github.cdsap.gcreport.plugin.histogram.Histogram
 import io.github.cdsap.gcreport.plugin.model.Bucket
 import io.github.cdsap.gcreport.plugin.model.GCReportMetrics
 import io.github.cdsap.gcreport.plugin.parser.GCLogReader
-import org.gradle.api.file.Directory
-import org.gradle.api.provider.Provider
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
 import org.gradle.tooling.events.FinishEvent
@@ -18,11 +19,11 @@ import java.io.File
 
 abstract class GCReportService : BuildService<GCReportService.Params>, AutoCloseable, OperationCompletionListener {
     interface Params : BuildServiceParameters {
-        var logs: Provider<List<String>>
-        var histogramEnabled: Provider<Boolean>
-        var histogramBucket: Provider<Bucket>
-        var buildOutput: Provider<Directory>
-        var enabledReport: Provider<Boolean>
+        val logs: ListProperty<String>
+        val histogramEnabled: Property<Boolean>
+        val histogramBucket: Property<Bucket>
+        val buildOutput: DirectoryProperty
+        val enabledReport: Property<Boolean>
     }
 
     override fun onFinish(event: FinishEvent?) {}

--- a/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/ServiceHandler.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/ServiceHandler.kt
@@ -17,12 +17,15 @@ class ServiceHandler(
                 "gcReportService",
                 GCReportService::class.java,
             ) {
-                val buildOutput = project.layout.buildDirectory.dir("reports/gcreport")
-                parameters.logs = extension.logs
-                parameters.histogramEnabled = extension.histogramEnabled
-                parameters.histogramBucket = extension.histogramBucket
-                parameters.buildOutput = buildOutput
-                parameters.enabledReport = if (enableLog == null) project.provider { true } else enableLog
+                parameters.logs.set(extension.logs)
+                parameters.histogramEnabled.set(extension.histogramEnabled)
+                parameters.histogramBucket.set(extension.histogramBucket)
+                parameters.buildOutput.set(project.layout.buildDirectory.dir("reports/gcreport"))
+                if (enableLog == null) {
+                    parameters.enabledReport.convention(true)
+                } else {
+                    parameters.enabledReport.set(enableLog)
+                }
             }
         project.serviceOf<BuildEventsListenerRegistry>().onTaskCompletion(service)
     }

--- a/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportServiceRegistrationTest.kt
+++ b/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportServiceRegistrationTest.kt
@@ -38,11 +38,35 @@ class GCReportServiceRegistrationTest {
         assertTrue(serviceHandler.contains("histogramBucket"))
         assertTrue(serviceHandler.contains("buildOutput"))
         assertTrue(serviceHandler.contains("parameters.logs"))
+        assertTrue(serviceHandler.contains("parameters.logs.set("))
+        assertTrue(serviceHandler.contains("parameters.enabledReport.convention(true)"))
+        assertFalse(serviceHandler.contains("project.provider"))
 
         val plugin = kotlinSources.single { it.name == "GCReportPlugin.kt" }.readText()
         assertTrue(plugin.contains("ServiceHandler"))
         assertFalse(plugin.contains("registerIfAbsent"))
         assertFalse(plugin.contains("\"gcReportService\""))
+        assertTrue(plugin.contains("histogramEnabled.convention(false)"))
+        assertTrue(plugin.contains("histogramBucket.convention("))
+        assertTrue(plugin.contains("enableConsoleLog.convention(false)"))
+
+        val service = kotlinSources.single { it.name == "GCReportService.kt" }.readText()
+        assertTrue(service.contains("val logs: ListProperty<String>"))
+        assertTrue(service.contains("val histogramEnabled: Property<Boolean>"))
+        assertTrue(service.contains("val histogramBucket: Property<Bucket>"))
+        assertTrue(service.contains("val buildOutput: DirectoryProperty"))
+        assertTrue(service.contains("val enabledReport: Property<Boolean>"))
+        assertFalse(service.contains("var logs:"))
+        assertFalse(service.contains("Provider<List<String>>"))
+
+        val extension = kotlinSources.single { it.name == "GCReportExtension.kt" }.readText()
+        assertTrue(extension.contains("abstract class GCReportExtension"))
+        assertTrue(extension.contains("abstract val logs: ListProperty<String>"))
+        assertTrue(extension.contains("abstract val histogramEnabled: Property<Boolean>"))
+        assertTrue(extension.contains("abstract val histogramBucket: Property<Bucket>"))
+        assertTrue(extension.contains("abstract val enableConsoleLog: Property<Boolean>"))
+        assertFalse(extension.contains("ObjectFactory"))
+        assertFalse(extension.contains("open class GCReportExtension"))
     }
 
     @Test
@@ -131,5 +155,45 @@ class GCReportServiceRegistrationTest {
         assertFalse(result.output.contains("GC Log: gc.log"))
         assertFalse(result.output.contains("Collection type"))
         assertFalse(testProjectDir.resolve("build/reports/gcreport/gc.csv").exists())
+    }
+
+    @Test
+    fun `managed extension conventions remain overridable by consumers`() {
+        val gradleProperties = File(testProjectDir, "gradle.properties")
+        val gcLog = "${testProjectDir.absolutePath}/gc.log"
+        gradleProperties.writeText(
+            """
+            org.gradle.jvmargs=-Xlog:gc*:file=$gcLog
+            """.trimIndent(),
+        )
+
+        val buildFile = File(testProjectDir, "build.gradle.kts")
+        buildFile.writeText(
+            """
+            plugins {
+                id("io.github.cdsap.gcreport")
+                java
+            }
+
+            gcReport {
+                logs.set(listOf("$gcLog"))
+                histogramEnabled.set(true)
+                histogramBucket.set(io.github.cdsap.gcreport.plugin.model.Bucket.SquareRoot)
+            }
+            """,
+        )
+
+        val result =
+            GradleRunner.create()
+                .withProjectDir(testProjectDir)
+                .withArguments("tasks")
+                .withPluginClasspath()
+                .build()
+
+        assertTrue(result.output.contains("GC Log: gc.log"))
+        assertTrue(result.output.contains("GC Histogram: gc.log"))
+        assertTrue(result.output.contains("Type: SquareRoot"))
+        assertTrue(testProjectDir.resolve("build/reports/gcreport/gc.csv").exists())
+        assertTrue(testProjectDir.resolve("build/reports/gcreport/histogram_gc.csv").exists())
     }
 }


### PR DESCRIPTION
## Summary

### Problem

Two places declare Gradle properties in a non-idiomatic way.

**1. `GCReportService.kt:20-26`** — the build service parameters use mutable `var` fields typed as `Provider<T>`:

```kotlin
interface Params : BuildServiceParameters {
    var logs: Provider<List<String>>
    var histogramEnabled: Provider<Boolean>
    var histogramBucket: Provider<Bucket>
    var buildOutput: Provider<Directory>
    var enabledReport: Provider<Boolean>
}
```

**2. `GCReportExtension.kt:8`** — the extension is an `open class` with concrete `val` properties and a hand-injected `ObjectFactory`:

```kotlin
open class GCReportExtension(objects: ObjectFactory) {
    val logs: ListProperty<String> = objects.listProperty(String::class.java)
    // ...
}
```

Fixes #30

## Changes

- `gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/GCReportExtension.kt`
- `gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/GCReportPlugin.kt`
- `gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/GCReportService.kt`
- `gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/ServiceHandler.kt`
- `gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportServiceRegistrationTest.kt`

## Verification

- `./gradlew ktlintCheck`
- `./gradlew test`
