### PR TITLE
fix: replace println with a gradle logger in gcreportservice

### DIFF
--- a/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/GCReportService.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/GCReportService.kt
@@ -9,6 +9,7 @@ import io.github.cdsap.gcreport.plugin.model.Bucket
 import io.github.cdsap.gcreport.plugin.model.GCReportMetrics
 import io.github.cdsap.gcreport.plugin.parser.GCLogReader
 import org.gradle.api.file.Directory
+import org.gradle.api.logging.Logging
 import org.gradle.api.provider.Provider
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
@@ -24,6 +25,8 @@ abstract class GCReportService : BuildService<GCReportService.Params>, AutoClose
         var buildOutput: Provider<Directory>
         var enabledReport: Provider<Boolean>
     }
+
+    private val logger = Logging.getLogger(GCReportService::class.java)
 
     override fun onFinish(event: FinishEvent?) {}
 
@@ -41,7 +44,7 @@ abstract class GCReportService : BuildService<GCReportService.Params>, AutoClose
                 val headers = "Collection type,Occurrences\n"
                 var content = ""
                 val metrics = GCReportMetrics.from(gcEntries)
-                println(
+                logger.lifecycle(
                     table {
                         cellStyle {
                             alignment = TextAlignment.MiddleLeft
@@ -74,7 +77,7 @@ abstract class GCReportService : BuildService<GCReportService.Params>, AutoClose
                     val headersHistogram = "Bucket,Occurrences\n"
                     var contentHistogram = ""
 
-                    println(
+                    logger.lifecycle(
                         table {
                             cellStyle {
                                 alignment = TextAlignment.MiddleLeft
@@ -104,7 +107,7 @@ abstract class GCReportService : BuildService<GCReportService.Params>, AutoClose
                                     }
                                 }
                             }
-                        },
+                        }.toString(),
                     )
                     fileHistogram.writeText(headersHistogram + contentHistogram)
                 }

--- a/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportPluginWithoutDevelocityTest.kt
+++ b/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportPluginWithoutDevelocityTest.kt
@@ -1,6 +1,7 @@
 package io.github.cdsap.gcreport.plugin
 
 import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -124,6 +125,48 @@ class GCReportPluginWithoutDevelocityTest {
         assertTrue(result.output.contains("Collection type"))
         assertTrue(result.output.contains("GC Histogram: gc.log"))
         assertTrue(result.output.contains("Type: SquareRoot"))
+        assertTrue(testProjectDir.resolve("build/reports/gcreport/gc.csv").exists())
+        assertTrue(testProjectDir.resolve("build/reports/gcreport/histogram_gc.csv").exists())
+    }
+
+    @Test
+    fun `plugin report output is suppressed with quiet`() {
+        val gradleProperties = File(testProjectDir, "gradle.properties")
+        val gcLog = "${testProjectDir.absolutePath}/gc.log"
+        gradleProperties.writeText(
+            """
+            org.gradle.jvmargs=-Xlog:gc*:file=$gcLog
+            """.trimIndent(),
+        )
+
+        val buildFile = File(testProjectDir, "build.gradle.kts")
+
+        buildFile.writeText(
+            """
+            plugins {
+                id("io.github.cdsap.gcreport")
+                java
+            }
+
+            gcReport {
+                logs.set(listOf("$gcLog"))
+                histogramEnabled.set(true)
+                histogramBucket.set(io.github.cdsap.gcreport.plugin.model.Bucket.SquareRoot)
+            }
+            """,
+        )
+
+        val result =
+            GradleRunner.create()
+                .withProjectDir(testProjectDir)
+                .withArguments("tasks", "--quiet")
+                .withPluginClasspath()
+                .build()
+
+        assertFalse(result.output.contains("GC Log: gc.log"))
+        assertFalse(result.output.contains("Collection type"))
+        assertFalse(result.output.contains("GC Histogram: gc.log"))
+        assertFalse(result.output.contains("Type: SquareRoot"))
         assertTrue(testProjectDir.resolve("build/reports/gcreport/gc.csv").exists())
         assertTrue(testProjectDir.resolve("build/reports/gcreport/histogram_gc.csv").exists())
     }

--- a/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportServiceRegistrationTest.kt
+++ b/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportServiceRegistrationTest.kt
@@ -46,6 +46,22 @@ class GCReportServiceRegistrationTest {
     }
 
     @Test
+    fun `main sources do not use println`() {
+        val mainSources = File("src/main")
+        require(mainSources.isDirectory) { "Expected sources at ${mainSources.absolutePath}" }
+
+        val offenders =
+            mainSources
+                .walkTopDown()
+                .filter { it.isFile && it.extension in setOf("kt", "java") }
+                .filter { it.readText().contains("println(") }
+                .map { it.relativeTo(mainSources).path }
+                .toList()
+
+        assertTrue(offenders.isEmpty(), "println found in src/main: $offenders")
+    }
+
+    @Test
     fun `without Develocity console report remains enabled by default registration path`() {
         val gradleProperties = File(testProjectDir, "gradle.properties")
         val gcLog = "${testProjectDir.absolutePath}/gc.log"


### PR DESCRIPTION
## Summary

### Problem

The build service writes its user-facing report with `println` — `GCReportService.kt:44` (collection-type table) and `GCReportService.kt:77` (histogram table).

Fixes #31

## Changes

- `gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/GCReportService.kt`
- `gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportPluginWithoutDevelocityTest.kt`
- `gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportServiceRegistrationTest.kt`

## Verification

- `./gradlew ktlintCheck`
- `./gradlew test`
