### PR TITLE
fix: clean up gcreportplugin.apply: unused rootproject receiver and eage

### DIFF
--- a/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/GCReportPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/GCReportPlugin.kt
@@ -8,11 +8,9 @@ import org.gradle.kotlin.dsl.create
 
 class GCReportPlugin : Plugin<Project> {
     override fun apply(target: Project) {
-        target.extensions.create<GCReportExtension>("gcReport")
-        val develocityConfiguration =
-            target.gradle.rootProject.extensions.findByType(DevelocityConfiguration::class.java)
+        val extension = target.extensions.create<GCReportExtension>("gcReport")
         target.gradle.rootProject {
-            val extension = target.extensions.getByName("gcReport") as GCReportExtension
+            val develocityConfiguration = extensions.findByType(DevelocityConfiguration::class.java)
             if (develocityConfiguration != null) {
                 ServiceHandler(target, extension, extension.enableConsoleLog).createService()
                 DevelocityReport(develocityConfiguration, extension).report()

--- a/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportServiceRegistrationTest.kt
+++ b/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportServiceRegistrationTest.kt
@@ -132,4 +132,40 @@ class GCReportServiceRegistrationTest {
         assertFalse(result.output.contains("Collection type"))
         assertFalse(testProjectDir.resolve("build/reports/gcreport/gc.csv").exists())
     }
+
+    @Test
+    fun `apply reuses extension instance and looks up Develocity inside rootProject receiver`() {
+        val plugin =
+            File("src/main/kotlin/io/github/cdsap/gcreport/plugin/GCReportPlugin.kt").readText()
+
+        assertTrue(
+            plugin.contains("val extension = target.extensions.create<GCReportExtension>(\"gcReport\")"),
+        )
+        assertFalse(plugin.contains("getByName(\"gcReport\")"))
+        assertFalse(plugin.contains("as GCReportExtension"))
+
+        val applyBody =
+            plugin
+                .substringAfter("override fun apply(target: Project) {")
+                .substringBeforeLast("}")
+                .trim()
+        val rootProjectBlockStart = applyBody.indexOf("target.gradle.rootProject {")
+        assertTrue(rootProjectBlockStart >= 0, "expected rootProject receiver block")
+
+        val beforeRootProject = applyBody.substring(0, rootProjectBlockStart)
+        assertFalse(
+            beforeRootProject.contains("findByType"),
+            "Develocity lookup must not run eagerly before the rootProject block",
+        )
+
+        val rootProjectBlock = applyBody.substring(rootProjectBlockStart)
+        assertTrue(
+            rootProjectBlock.contains("extensions.findByType(DevelocityConfiguration::class.java)"),
+            "Develocity lookup should use the rootProject receiver",
+        )
+        assertFalse(
+            rootProjectBlock.contains("target.gradle.rootProject.extensions.findByType"),
+            "unused rootProject receiver: lookup should not re-qualify through target.gradle.rootProject",
+        )
+    }
 }


### PR DESCRIPTION
## Summary

### Problem

`GCReportPlugin.kt:14-27`:

```kotlin
override fun apply(target: Project) {
    target.extensions.create<GCReportExtension>("gcReport")
    val develocityConfiguration =
        target.gradle.rootProject.extensions.findByType(DevelocityConfiguration::class.java)
    target.gradle.rootProject {
        val extension = target.extensions.getByName("gcReport") as GCReportExtension
        if (develocityConfiguration != null) {
            createService(target, extension, extension.enableConsoleLog)
            DevelocityReport(develocityConfiguration, extension).report()
        } else {
            createService(target, extension)
        }
    }
}
```

Two readability/robustness problems:

1. **The `rootProject { }` receiver is unused.** The block's only purpose is to defer execution until the root project is available, but the body operates on `target`, not on the `Project` receiver the lambda provides. A reader reasonably expects the receiver to be used.
2. **`findByType` runs eagerly, outside the deferred block** (line 16-17), while everything that depends on its result runs inside. The detection is therefore sensitive to plugin application order.
3. The extension is created on line 15 and then re-fetched by string name and cast on line 19, rather than using the instance `create` already returned.

Fixes #32

## Changes

- `gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/GCReportPlugin.kt`
- `gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportServiceRegistrationTest.kt`

## Verification

- `./gradlew ktlintCheck`
- `./gradlew test`
