### PR TITLE
fix: develocity test is env-gated, hardcodes its version, and may config

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -22,6 +22,8 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+    // Keep TestKit fixtures on the same Develocity version as libs.versions.toml
+    systemProperty("develocityPluginVersion", libs.versions.develocity.get())
 }
 gradlePlugin {
     website = "https://github.com/cdsap/GCReport"

--- a/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/DevelocityTestSupport.kt
+++ b/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/DevelocityTestSupport.kt
@@ -1,0 +1,18 @@
+package io.github.cdsap.gcreport.plugin
+
+internal object DevelocityTestSupport {
+    fun pluginVersion(): String =
+        checkNotNull(System.getProperty("develocityPluginVersion")) {
+            "Missing develocityPluginVersion system property; set it from libs.versions.develocity in build.gradle.kts"
+        }
+
+    fun settingsScript(configureBody: String): String =
+        """
+        plugins {
+            id("com.gradle.develocity") version "${pluginVersion()}"
+        }
+        develocity {
+            $configureBody
+        }
+        """.trimIndent()
+}

--- a/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportPluginWithDevelocityTest.kt
+++ b/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportPluginWithDevelocityTest.kt
@@ -12,6 +12,7 @@ import io.ktor.client.request.parameter
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
@@ -22,6 +23,55 @@ import kotlin.random.Random
 class GCReportPluginWithDevelocityTest {
     @TempDir
     lateinit var testProjectDir: File
+
+    @Test
+    fun `plugin takes Develocity path without requiring live server credentials`() {
+        val gcFile = "gc.log"
+        val gradleProperties = File(testProjectDir, "gradle.properties")
+        val gcLog = "${testProjectDir.absolutePath}/$gcFile"
+        gradleProperties.writeText(
+            """
+            org.gradle.jvmargs=-Xlog:gc*:file=$gcLog
+            """.trimIndent(),
+        )
+
+        File(testProjectDir, "settings.gradle.kts").writeText(
+            DevelocityTestSupport.settingsScript(
+                """
+                buildScan {
+                    publishing.onlyIf { false }
+                }
+                """.trimIndent(),
+            ),
+        )
+
+        File(testProjectDir, "build.gradle.kts").writeText(
+            """
+            plugins {
+                id("io.github.cdsap.gcreport")
+                java
+            }
+
+            gcReport {
+                logs.set(listOf("$gcLog"))
+            }
+            """,
+        )
+
+        val result =
+            GradleRunner.create()
+                .withProjectDir(testProjectDir)
+                .withArguments("tasks")
+                .withPluginClasspath()
+                .build()
+
+        // DevelocityConfiguration is present, so GCReportPlugin takes the Develocity branch
+        // (console/CSV reporting stays off unless enableConsoleLog is explicitly enabled).
+        assertFalse(result.output.contains("GC Log: gc.log"))
+        assertFalse(result.output.contains("Collection type"))
+        assertFalse(testProjectDir.resolve("build/reports/gcreport/gc.csv").exists())
+        assertTrue(result.output.contains("BUILD SUCCESSFUL"))
+    }
 
     @Test
     fun `plugin generates Output with Gc report for G1`() {
@@ -44,20 +94,16 @@ class GCReportPluginWithDevelocityTest {
         val randomValue = Random.nextInt(Int.MAX_VALUE).toString()
 
         settingsGradle.writeText(
-            """
-            plugins {
-                id("com.gradle.develocity") version "3.19"
-            }
-            gradleEnterprise {
-                server = "$develocityUrl"
-                accessKey="$develocityAccessKey"
+            DevelocityTestSupport.settingsScript(
+                """
+                server.set("$develocityUrl")
+                accessKey.set("$develocityAccessKey")
                 buildScan {
-                      isUploadInBackground = false
+                      uploadInBackground = false
                       tag("$randomValue")
-
                 }
-            }
-            """.trimIndent(),
+                """.trimIndent(),
+            ),
         )
 
         val buildFile = File(testProjectDir, "build.gradle.kts")
@@ -130,20 +176,16 @@ class GCReportPluginWithDevelocityTest {
         val randomValue = Random.nextInt(Int.MAX_VALUE).toString()
 
         settingsGradle.writeText(
-            """
-            plugins {
-                id("com.gradle.develocity") version "3.19"
-            }
-            gradleEnterprise {
-                server = "$develocityUrl"
-                accessKey="$develocityAccessKey"
+            DevelocityTestSupport.settingsScript(
+                """
+                server.set("$develocityUrl")
+                accessKey.set("$develocityAccessKey")
                 buildScan {
-                      isUploadInBackground = false
+                      uploadInBackground = false
                       tag("$randomValue")
-
                 }
-            }
-            """.trimIndent(),
+                """.trimIndent(),
+            ),
         )
 
         val buildFile = File(testProjectDir, "build.gradle.kts")
@@ -208,20 +250,16 @@ class GCReportPluginWithDevelocityTest {
         val randomValue = Random.nextInt(Int.MAX_VALUE).toString()
 
         settingsGradle.writeText(
-            """
-            plugins {
-                id("com.gradle.develocity") version "3.19"
-            }
-            gradleEnterprise {
-                server = "$develocityUrl"
-                accessKey="$develocityAccessKey"
+            DevelocityTestSupport.settingsScript(
+                """
+                server.set("$develocityUrl")
+                accessKey.set("$develocityAccessKey")
                 buildScan {
-                      isUploadInBackground = false
+                      uploadInBackground = false
                       tag("$randomValue")
-
                 }
-            }
-            """.trimIndent(),
+                """.trimIndent(),
+            ),
         )
 
         val gradleProperties = File(testProjectDir, "gradle.properties")

--- a/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportServiceRegistrationTest.kt
+++ b/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportServiceRegistrationTest.kt
@@ -94,16 +94,13 @@ class GCReportServiceRegistrationTest {
 
         val settingsGradle = File(testProjectDir, "settings.gradle.kts")
         settingsGradle.writeText(
-            """
-            plugins {
-                id("com.gradle.develocity") version "3.19"
-            }
-            develocity {
+            DevelocityTestSupport.settingsScript(
+                """
                 buildScan {
                     publishing.onlyIf { false }
                 }
-            }
-            """.trimIndent(),
+                """.trimIndent(),
+            ),
         )
 
         val buildFile = File(testProjectDir, "build.gradle.kts")

--- a/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GradlePluginBuildConfigTest.kt
+++ b/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GradlePluginBuildConfigTest.kt
@@ -26,4 +26,25 @@ class GradlePluginBuildConfigTest {
             "gradle/libs.versions.toml must declare junit-platform-launcher",
         )
     }
+
+    @Test
+    fun `test task injects Develocity plugin version from the version catalog`() {
+        val buildGradle = File("build.gradle.kts").canonicalFile
+        val buildGradleContents = buildGradle.readText()
+
+        assertTrue(
+            buildGradleContents.contains("systemProperty(\"develocityPluginVersion\", libs.versions.develocity.get())"),
+            "build.gradle.kts must inject libs.versions.develocity into tests",
+        )
+
+        val versionCatalog = File("../gradle/libs.versions.toml").canonicalFile.readText()
+        val catalogVersion =
+            Regex("""(?m)^develocity\s*=\s*"([^"]+)"""").find(versionCatalog)?.groupValues?.get(1)
+        requireNotNull(catalogVersion) { "develocity version missing from libs.versions.toml" }
+
+        assertTrue(
+            DevelocityTestSupport.pluginVersion() == catalogVersion,
+            "TestKit Develocity version must match the version catalog ($catalogVersion)",
+        )
+    }
 }


### PR DESCRIPTION
## Summary

### Problem

`GCReportPluginWithDevelocityTest.kt` — the only coverage of the Develocity reporting path — has three issues that together mean it likely never validates anything.

**1. It is skipped unless secrets are present** (line 27):

```kotlin
assumeTrue(
    System.getenv("GE_URL") != null && System.getenv("GE_API_KEY") != null,
    "Develocity URL and Access Key are set",
)
```

On any fork, any local run without those env vars, and any CI run where the secrets are unset, JUnit reports this as skipped, not failed — so the Develocity path is silently untested.

**2. It hardcodes the plugin version** instead of using the version catalog:

```kotlin
id("com.gradle.develocity") version "3.19"
```

`gradle/libs.versions.toml` pins `develocity = "3.19.1"`. So the code compiles against 3.19.1 but the functional test exercises 3.19 — the versions drift independently and Renovate will only update one of them.

**3. It configures the modern plugin id through the legacy extension.** The test applies `com.gradle.develocity` but then configures it with:

```kotlin
gradleEnterprise {
    server = "$develocityUrl"
    buildScan { isUploadInBackground = false; ... }
}
```

`com.gradle.develocity` registers the `develocity { }` extension; `gradleEnterprise { }` belongs to the legacy `com.gradle.enterprise` plugin id. **This is worth verifying before fixing** — the plugin jar ships both `DevelocityConfiguration` and the legacy `GradleEnterpriseExtension`/`GradleEnterprisePlugin` classes, so it is possible the legacy extension is still registered for compatibility. If it is not, this generated build script fails or leaves the scan unconfigured, and the assertions are running against an unconfigured build scan.

Fixes #34

## Changes

- `gradle-plugin/build.gradle.kts`
- `gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/DevelocityTestSupport.kt`
- `gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportPluginWithDevelocityTest.kt`
- `gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportServiceRegistrationTest.kt`
- `gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GradlePluginBuildConfigTest.kt`

## Verification

- `./gradlew ktlintCheck`
- `./gradlew test`
