### PR TITLE
fix: document supported gradle version, java version, and gc log formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,15 @@ If [Develocity](https://gradle.com/develocity/) is configured in the project, th
 Analyzing the types of garbage collections that occurred during the build can provide valuable insights into performance issues.
 
 **This plugin is intended for performance investigations and is not meant to be enabled in regular builds.**
+### Compatibility
+* **Gradle:** **8.9+**. The plugin currently resolves `BuildEventsListenerRegistry` through Gradle's internal `org.gradle.internal.extensions.core.serviceOf` helper, which exists at that path starting in Gradle 8.9.
+* **Java:** **11+**. Published plugin bytecode is pinned with `jvmToolchain(11)` in `gradle-plugin/build.gradle.kts`, so the class-file target does not depend on which JDK runs the release build. The Gradle daemon that loads the plugin must therefore run on Java 11 or newer.
+* **GC collectors / log formats:** Unified JVM logging (`-Xlog:gc*`, as in the examples below). Test fixtures cover **G1** and **Parallel**. Other collectors (for example ZGC) are not validated.
+
 ### Usage
 #### Apply the plugin
+Plugin id / marker: `io.github.cdsap.gcreport` (current version `0.1.0`).
+
 ```kotlin
 plugins {
   id("io.github.cdsap.gcreport") version "0.1.0"
@@ -99,9 +106,7 @@ Bucket,Occurrences
 ```
 
 ### Considerations
-* Supported GC types:
-    - G1
-    - Parallel
+* Supported GC collectors and log formats are listed under [Compatibility](#compatibility).
 * The plugin output may be unreliable for incremental builds where log rotations have occurred.
 
 

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -10,6 +10,10 @@ plugins {
 group = "io.github.cdsap"
 version = "0.1.0"
 
+kotlin {
+    jvmToolchain(11)
+}
+
 dependencies {
     implementation(libs.develocity)
     implementation(libs.picnic)

--- a/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/CompatibilityDocumentationTest.kt
+++ b/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/CompatibilityDocumentationTest.kt
@@ -1,0 +1,88 @@
+package io.github.cdsap.gcreport.plugin
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class CompatibilityDocumentationTest {
+    @Test
+    fun `readme documents gradle java and gc compatibility matching the build`() {
+        val readme = File("../README.md").canonicalFile
+        assertTrue(readme.isFile, "README should exist at ${readme.path}")
+        val readmeText = readme.readText()
+
+        val buildGradle = File("build.gradle.kts").canonicalFile.readText()
+        val toolchainMatch = TOOLCHAIN_REGEX.find(buildGradle)
+        assertTrue(
+            toolchainMatch != null,
+            "build.gradle.kts must pin kotlin jvmToolchain so README Java floor is real",
+        )
+        val toolchainJava = toolchainMatch!!.groupValues[1]
+
+        assertTrue(
+            readmeText.contains("### Compatibility"),
+            "README must include a Compatibility section",
+        )
+        assertTrue(
+            Regex("""Gradle[:\s*]*\**${Regex.escape(MINIMUM_GRADLE_VERSION)}\+\**""")
+                .containsMatchIn(readmeText),
+            "README must document minimum Gradle $MINIMUM_GRADLE_VERSION+",
+        )
+        assertTrue(
+            Regex("""Java[:\s*]*\**${Regex.escape(toolchainJava)}\+?\**""")
+                .containsMatchIn(readmeText),
+            "README minimum Java must match jvmToolchain($toolchainJava)",
+        )
+        assertTrue(
+            readmeText.contains("-Xlog:gc"),
+            "README must state the supported unified JVM GC log format (-Xlog:gc*)",
+        )
+        assertTrue(
+            readmeText.contains("G1") && readmeText.contains("Parallel"),
+            "README must state supported GC collectors G1 and Parallel",
+        )
+    }
+
+    @Test
+    fun `readme plugins snippet uses the current plugin id and version`() {
+        val readmeText = File("../README.md").canonicalFile.readText()
+        val buildGradle = File("build.gradle.kts").canonicalFile.readText()
+
+        val versionMatch = VERSION_REGEX.find(buildGradle)
+        assertTrue(versionMatch != null, "build.gradle.kts must declare version")
+        val version = versionMatch!!.groupValues[1]
+
+        assertTrue(
+            readmeText.contains("""id("io.github.cdsap.gcreport") version "$version""""),
+            "README plugins snippet must use id io.github.cdsap.gcreport and version $version",
+        )
+
+        val pluginIdMatch = PLUGIN_ID_REGEX.find(buildGradle)
+        assertEquals(
+            "io.github.cdsap.gcreport",
+            pluginIdMatch?.groupValues?.get(1),
+            "Published plugin id must remain io.github.cdsap.gcreport",
+        )
+    }
+
+    @Test
+    fun `service handler still depends on the gradle 8_9 serviceOf package`() {
+        val serviceHandler =
+            File("src/main/kotlin/io/github/cdsap/gcreport/plugin/ServiceHandler.kt")
+                .canonicalFile
+                .readText()
+
+        assertTrue(
+            serviceHandler.contains("org.gradle.internal.extensions.core.serviceOf"),
+            "Minimum Gradle $MINIMUM_GRADLE_VERSION+ in the README is tied to this serviceOf import path",
+        )
+    }
+
+    private companion object {
+        const val MINIMUM_GRADLE_VERSION = "8.9"
+        val TOOLCHAIN_REGEX = Regex("""jvmToolchain\((\d+)\)""")
+        val VERSION_REGEX = Regex("""(?m)^version\s*=\s*"([^"]+)"""")
+        val PLUGIN_ID_REGEX = Regex("""(?m)^\s*id\s*=\s*"([^"]+)"""")
+    }
+}


### PR DESCRIPTION
## Summary

### Problem

`README.md` documents configuration and usage but states no supported Gradle version and no minimum Java version.

Fixes #36

## Changes

- `README.md`
- `gradle-plugin/build.gradle.kts`
- `gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/CompatibilityDocumentationTest.kt`

## Verification

- `./gradlew ktlintCheck`
- `./gradlew test`
