### PR TITLE
fix: provider.get() called outside a task action in the develocity repor

### DIFF
--- a/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/output/DevelocityValues.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/output/DevelocityValues.kt
@@ -1,9 +1,9 @@
 package io.github.cdsap.gcreport.plugin.output
 
 import com.gradle.develocity.agent.gradle.DevelocityConfiguration
-import io.github.cdsap.gcreport.plugin.GCReportExtension
 import io.github.cdsap.gcreport.plugin.extensions.getFileName
 import io.github.cdsap.gcreport.plugin.histogram.Histogram
+import io.github.cdsap.gcreport.plugin.model.Bucket
 import io.github.cdsap.gcreport.plugin.model.GCEntry
 import io.github.cdsap.gcreport.plugin.model.GCReportMetrics
 
@@ -11,7 +11,8 @@ class DevelocityValues(
     private val develocityConfiguration: DevelocityConfiguration,
     private val gcEntries: List<GCEntry>,
     private val log: String,
-    private val extension: GCReportExtension,
+    private val histogramEnabled: Boolean,
+    private val histogramBucket: Bucket,
 ) {
     fun report() {
         val metrics = GCReportMetrics.from(gcEntries)
@@ -23,9 +24,9 @@ class DevelocityValues(
             if (counter != 0) {
                 value("gc-${log.getFileName()}-total-collections", "$counter")
             }
-            if (extension.histogramEnabled.get()) {
+            if (histogramEnabled) {
                 val histogram =
-                    Histogram(extension.histogramBucket.get()).getHistogram(
+                    Histogram(histogramBucket).getHistogram(
                         metrics.entriesForHistogram(),
                     )
                 var histogramText = "["

--- a/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/report/DevelocityReport.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/report/DevelocityReport.kt
@@ -12,9 +12,18 @@ class DevelocityReport(
 ) {
     fun report() {
         develocityConfiguration.buildScan.buildFinished {
-            extension.logs.get().filter { File(it).exists() }.forEach {
+            val logs = extension.logs.get()
+            val histogramEnabled = extension.histogramEnabled.get()
+            val histogramBucket = extension.histogramBucket.get()
+            logs.filter { File(it).exists() }.forEach {
                 val gcEntries = GCLogReader(File(it)).parse()
-                DevelocityValues(develocityConfiguration, gcEntries, it, extension).report()
+                DevelocityValues(
+                    develocityConfiguration,
+                    gcEntries,
+                    it,
+                    histogramEnabled,
+                    histogramBucket,
+                ).report()
             }
         }
     }

--- a/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportServiceRegistrationTest.kt
+++ b/gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportServiceRegistrationTest.kt
@@ -70,6 +70,24 @@ class GCReportServiceRegistrationTest {
     }
 
     @Test
+    fun `Develocity providers are resolved only inside buildFinished`() {
+        val values = kotlinSources().single { it.name == "DevelocityValues.kt" }.readText()
+        val report = kotlinSources().single { it.name == "DevelocityReport.kt" }.readText()
+
+        assertFalse(values.contains("GCReportExtension"))
+        assertFalse(values.contains(".get()"))
+        assertTrue(values.contains("histogramEnabled: Boolean"))
+        assertTrue(values.contains("histogramBucket: Bucket"))
+
+        val buildFinishedIndex = report.indexOf("develocityConfiguration.buildScan.buildFinished")
+        assertTrue(buildFinishedIndex >= 0)
+        assertTrue(buildFinishedIndex < report.indexOf("extension.logs.get()"))
+        assertTrue(buildFinishedIndex < report.indexOf("extension.histogramEnabled.get()"))
+        assertTrue(buildFinishedIndex < report.indexOf("extension.histogramBucket.get()"))
+        assertFalse(report.substring(0, buildFinishedIndex).contains(".get()"))
+    }
+
+    @Test
     fun `without Develocity console report remains enabled by default registration path`() {
         val gradleProperties = File(testProjectDir, "gradle.properties")
         val gcLog = "${testProjectDir.absolutePath}/gc.log"
@@ -196,4 +214,6 @@ class GCReportServiceRegistrationTest {
         assertTrue(testProjectDir.resolve("build/reports/gcreport/gc.csv").exists())
         assertTrue(testProjectDir.resolve("build/reports/gcreport/histogram_gc.csv").exists())
     }
+
+    private fun kotlinSources(): List<File> = File("src/main/kotlin").walkTopDown().filter { it.isFile && it.extension == "kt" }.toList()
 }


### PR DESCRIPTION
## Summary

### Problem

Three sites call `.get()` on extension providers outside of any task action:

- `output/DevelocityValues.kt:26` — `extension.histogramEnabled.get()`
- `output/DevelocityValues.kt:28` — `extension.histogramBucket.get()`
- `report/DevelocityReport.kt:15` — `extension.logs.get()`

These run inside the `develocityConfiguration.buildScan.buildFinished { }` callback, which is registered during the configuration phase. There is no task action anywhere in this plugin, so the provider values are read eagerly rather than being wired lazily.

Fixes #38

## Changes

- `gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/output/DevelocityValues.kt`
- `gradle-plugin/src/main/kotlin/io/github/cdsap/gcreport/plugin/report/DevelocityReport.kt`
- `gradle-plugin/src/test/java/io/github/cdsap/gcreport/plugin/GCReportServiceRegistrationTest.kt`

## Verification

- `./gradlew ktlintCheck`
- `./gradlew test`
